### PR TITLE
fixed failed when create table of tdengine

### DIFF
--- a/IoTSharp.Data.TimeSeries/TaosStorage.cs
+++ b/IoTSharp.Data.TimeSeries/TaosStorage.cs
@@ -33,6 +33,7 @@ namespace IoTSharp.Storage
             if (_taos.State != System.Data.ConnectionState.Open) _taos.Open();
             _taos.CreateCommand($"CREATE DATABASE IF NOT EXISTS {_taosBuilder.DataBase}").ExecuteNonQuery();
             _taos.ChangeDatabase(_taosBuilder.DataBase);
+            _taos.CreateCommand($"USE {_taosBuilder.DataBase}").ExecuteNonQuery();
             _taos.CreateCommand($"CREATE TABLE IF NOT EXISTS telemetrydata  (ts timestamp,value_type  tinyint, value_boolean bool, value_string binary(10240), value_long bigint,value_datetime timestamp,value_double double)   TAGS (deviceid binary(32),keyname binary(64));")
                .ExecuteNonQuery();
             return Task.FromResult(true);


### PR DESCRIPTION
we met the below message when database initialization, 
the message show create database is okay then create table failed. 

`
iotsharp-taos-1      | 07/31 15:58:41.522179 00000096 MND ERROR user:root, failed to login from 172.22.0.3 while use db:IoTSharp since Invalid database name, gtid:0xd03023f4dd720064:0x65931aaf4dd0007d
iotsharp-taos-1      | 07/31 15:58:41.522189 00000096 MND ERROR msg:0x7fc62841c868, failed to process since Invalid database name, app:0x7fa9dc004df0 type:connect, gtid:0xd03023f4dd720064:0x65931aaf4dd0007d
iotsharp-taos-1      | 07/31 15:58:41.523719 00000035 taos_ADAPTER info "| 200 |   75.661233ms |      172.22.0.5 | GET | %2Frest%2Fws " model=web
iotsharp-taos-1      | 07/31 15:58:41.527097 00000035 taos_ADAPTER info "| 200 |    7.591404ms |      172.22.0.5 | GET | %2Frest%2Fstmt " model=web
iotsharp-taos-1      | 07/31 15:58:41.528410 00000096 MND ERROR user:root, failed to login from 172.22.0.3 while use db:IoTSharp since Invalid database name, gtid:0xd03023f4dd780066:0x65931aaf4dd0007f
iotsharp-taos-1      | 07/31 15:58:41.528419 00000096 MND ERROR msg:0x7fc62641a9e8, failed to process since Invalid database name, app:0x7fa9c0020920 type:connect, gtid:0xd03023f4dd780066:0x65931aaf4dd0007f
iotsharp-taos-1      | failed to connect to server, reason: Invalid database name
iotsharp-taos-1      | 
iotsharp-taos-1      | 07/31 15:58:41.529946 00000096 MND ERROR user:root, failed to login from 172.22.0.3 while use db:IoTSharp since Invalid database name, gtid:0xd03023f4dd790068:0x65931aaf4dd00081
iotsharp-taos-1      | 07/31 15:58:41.529957 00000096 MND ERROR msg:0x7fc625c1c7a8, failed to process since Invalid database name, app:0x7fa9b40066f0 type:connect, gtid:0xd03023f4dd790068:0x65931aaf4dd00081
iotsharp-taos-1      | failed to connect to server, reason: Invalid database name
iotsharp-taos-1      | 
iotsharp-taos-1      | 07/31 15:58:41.535142 00000097 MND db:1.iotsharp, start to create, vgroups:2
iotsharp-taos-1      | 07/31 15:58:41.535151 00000097 MND db:1.iotsharp, already exist, ignore exist is set
iotsharp-taos-1      | 07/31 15:58:41.544216 00000035 taos_ADAPTER info "| 200 |   14.617762ms |      172.22.0.5 | GET | %2Frest%2Fstmt " model=web
iotsharp-taos-1      | 07/31 15:58:41.544217 00000035 taos_ADAPTER info "| 200 |   16.313725ms |      172.22.0.5 | GET | %2Frest%2Fws " model=web
iotsharp-taos-1      | 07/31 15:58:41.545403 00000096 MND ERROR user:root, failed to login from 172.22.0.3 while use db:IoTSharp since Invalid database name, gtid:0xd03023f4dd89006a:0x65931aaf4dd00086
iotsharp-taos-1      | 07/31 15:58:41.545411 00000096 MND ERROR msg:0x7fc6260177a8, failed to process since Invalid database name, app:0x7fa9d0004c70 type:connect, gtid:0xd03023f4dd89006a:0x65931aaf4dd00086
iotsharp-taos-1      | failed to connect to server, reason: Invalid database name
iotsharp-taos-1      | 
iotsharp-taos-1      | 07/31 15:58:41.547169 00000096 MND ERROR user:root, failed to login from 172.22.0.3 while use db:IoTSharp since Invalid database name, gtid:0xd03023f4dd8b006c:0x65931aaf4dd00088
iotsharp-taos-1      | 07/31 15:58:41.547176 00000096 MND ERROR msg:0x7fc625817868, failed to process since Invalid database name, app:0x7fa9b40066f0 type:connect, gtid:0xd03023f4dd8b006c:0x65931aaf4dd00088
iotsharp-taos-1      | failed to connect to server, reason: Invalid database name
iotsharp-taos-1      | 
iotsharp-iotsharp-1  | crit: Microsoft.AspNetCore.Hosting.Diagnostics[6]
iotsharp-iotsharp-1  |       Application startup exception
iotsharp-iotsharp-1  |       IoTSharp.Data.Taos.TaosException (0x00002616): Database not specified
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.TaosException.ThrowExceptionForRC(TaosErrorResult taosError)
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.Protocols.TDWebSocket.TaosWebSocket.Execute(String _commandText)
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.Protocols.TDWebSocket.TaosWebSocket.ExecuteReader(CommandBehavior behavior, TaosCommand command)
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.TaosCommand.ExecuteNonQuery()
iotsharp-iotsharp-1  |          at IoTSharp.Storage.TaosStorage.CheckTelemetryStorage() in /src/IoTSharp.Data.TimeSeries/TaosStorage.cs:line 36
iotsharp-iotsharp-1  |          at IoTSharp.IoTSharpExtension.UseTelemetryStorage(IApplicationBuilder app) in /src/IoTSharp/Extensions/IoTSharpExtension.cs:line 365
iotsharp-iotsharp-1  |          at IoTSharp.Startup.Configure(IApplicationBuilder app, IWebHostEnvironment env) in /src/IoTSharp/Startup.cs:line 349
iotsharp-iotsharp-1  |          at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
iotsharp-iotsharp-1  |          at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
iotsharp-iotsharp-1  |          at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
iotsharp-iotsharp-1  |          at Microsoft.AspNetCore.Hosting.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
iotsharp-iotsharp-1  |          at DotNetCore.CAP.CapStartupFilter.<>c__DisplayClass0_0.<Configure>b__0(IApplicationBuilder app)
iotsharp-iotsharp-1  |          at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync(CancellationToken cancellationToken)
`