### PR TITLE
avoid insert device data into database failed

### DIFF
--- a/IoTSharp.Data.TimeSeries/TaosStorage.cs
+++ b/IoTSharp.Data.TimeSeries/TaosStorage.cs
@@ -212,7 +212,7 @@ namespace IoTSharp.Storage
                             }
                             if (_hasvalue)
                             {
-                                string vals = $"device_{tdata.DeviceId:N}_{Pinyin4Net.GetPinyin(tdata.KeyName, PinyinFormat.WITHOUT_TONE).Replace(" ", string.Empty).Replace("@", string.Empty)} USING telemetrydata TAGS('{tdata.DeviceId:N}','{tdata.KeyName}')  (ts,value_type,{_type}) values (now,{(int)tdata.Type},{_value})";
+                                string vals = $"device_{tdata.DeviceId:N}_{Pinyin4Net.GetPinyin(tdata.KeyName, PinyinFormat.WITHOUT_TONE).Replace(" ", string.Empty).Replace("@", string.Empty).Replace(":", string.Empty)} USING telemetrydata TAGS('{tdata.DeviceId:N}','{tdata.KeyName}')  (ts,value_type,{_type}) values (now,{(int)tdata.Type},{_value})";
                                 lst.Add(vals);
                                 telemetries.Add(tdata);
                             }


### PR DESCRIPTION
The presence of a colon ':' in the table name will result in the following error message

iotsharp-iotsharp-1  | info: IoTSharp.Storage.TaosStorage[0]
iotsharp-iotsharp-1  |       INSERT INTO device_d2da441304a04ce1924410033e671235_gonglu: USING telemetrydata TAGS('d2da441304a04ce1924410033e671235','功率')  (ts,value_type,value_double) values (now,3,0)
iotsharp-iotsharp-1  |       device_d2da441304a04ce1924410033e671235_kaiguan USING telemetrydata TAGS('d2da441304a04ce1924410033e671235','开关')  (ts,value_type,value_double) values (now,3,1)
iotsharp-iotsharp-1  |       device_d2da441304a04ce1924410033e671235_yongdianliang USING telemetrydata TAGS('d2da441304a04ce1924410033e671235','用电量')  (ts,value_type,value_double) values (now,3,164700541)
iotsharp-iotsharp-1  |       device_d2da441304a04ce1924410033e671235_dianya USING telemetrydata TAGS('d2da441304a04ce1924410033e671235','电压')  (ts,value_type,value_double) values (now,3,5065)
iotsharp-iotsharp-1  |       device_d2da441304a04ce1924410033e671235_dianliu USING telemetrydata TAGS('d2da441304a04ce1924410033e671235','电流')  (ts,value_type,value_double) values (now,3,951979566)
iotsharp-iotsharp-1  | fail: IoTSharp.Storage.TaosStorage[0]
iotsharp-iotsharp-1  |       d2da4413-04a0-4ce1-9244-10033e671235数据处理失败9731-Table does not exist
iotsharp-iotsharp-1  |       IoTSharp.Data.Taos.TaosException (0x00002603): Table does not exist
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.TaosException.ThrowExceptionForRC(TaosErrorResult taosError)
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.Protocols.TDWebSocket.TaosWebSocket.Execute(String _commandText)
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.Protocols.TDWebSocket.TaosWebSocket.ExecuteReader(CommandBehavior behavior, TaosCommand command)
iotsharp-iotsharp-1  |          at IoTSharp.Data.Taos.TaosCommand.ExecuteNonQuery()
iotsharp-iotsharp-1  |          at System.Data.Common.DbCommand.ExecuteNonQueryAsync(CancellationToken cancellationToken)
iotsharp-iotsharp-1  |       --- End of stack trace from previous location ---
iotsharp-iotsharp-1  |          at IoTSharp.Storage.TaosStorage.StoreTelemetryAsync(PlayloadData msg) in /src/IoTSharp.Data.TimeSeries/TaosStorage.cs:line 225