### PR TITLE
fixed missed 'npm' error of Dockerfile

### DIFF
--- a/IoTSharp/Dockerfile
+++ b/IoTSharp/Dockerfile
@@ -22,7 +22,7 @@ RUN KEYRING=/usr/share/keyrings/nodesource.gpg && curl -fsSL https://deb.nodesou
 	VERSION=node_18.x &&  DISTRO=bookworm  && \
 	echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" |  tee /etc/apt/sources.list.d/nodesource.list && \
 	apt-get  -y   -q update  && \
-    apt-get install -y --no-install-recommends nodejs && \
+    apt-get install -y --no-install-recommends nodejs npm && \
 	ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
 	npm config set registry https://registry.npmmirror.com && \
 	export NODE_OPTIONS=--openssl-legacy-provider && \

--- a/IoTSharp/Dockerfile
+++ b/IoTSharp/Dockerfile
@@ -69,6 +69,7 @@ FROM build AS publish
 RUN dotnet publish "./IoTSharp.csproj" --no-restore   -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
+RUN chown -R app:app /app
 USER app
 WORKDIR /app
 COPY --from=publish /app/publish .


### PR DESCRIPTION
need explicit 'npm' into 'apt-get install nodejs'
for fixed missed 'npm' command
below is error report

```
10.28 update-alternatives: warning: skip creation of /usr/share/man/man1/js.1.gz because associated file /usr/share/man/man1/nodejs.1.gz (of link group js) doesn't exist
10.28 Processing triggers for libc-bin (2.36-9+deb12u3) ...
10.34 /bin/sh: 1: npm: not found
------
Dockerfile:20
--------------------
  19 |     		apt-get autoclean  
  20 | >>> RUN KEYRING=/usr/share/keyrings/nodesource.gpg && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor |  tee "$KEYRING" >/dev/null && \
  21 | >>> 	gpg --no-default-keyring --keyring "$KEYRING" --list-keys && \
  22 | >>> 	VERSION=node_18.x &&  DISTRO=bookworm  && \
  23 | >>> 	echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main" |  tee /etc/apt/sources.list.d/nodesource.list && \
  24 | >>> 	apt-get  -y   -q update  && \
  25 | >>>     apt-get install -y --no-install-recommends nodejs && \
  26 | >>> 	ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  27 | >>> 	npm config set registry https://registry.npmmirror.com && \
  28 | >>> 	export NODE_OPTIONS=--openssl-legacy-provider && \
  29 | >>> 	apt-get autoclean 
  30 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c KEYRING=/usr/share/keyrings/nodesource.gpg && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor |  tee \"$KEYRING\" >/dev/null && \tgpg --no-default-keyring --keyring \"$KEYRING\" --list-keys && \tVERSION=node_18.x &&  DISTRO=bookworm  && \techo \"deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRO main\" |  tee /etc/apt/sources.list.d/nodesource.list && \tapt-get  -y   -q update  &&     apt-get install -y --no-install-recommends nodejs && \tln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \tnpm config set registry https://registry.npmmirror.com && \texport NODE_OPTIONS=--openssl-legacy-provider && \tapt-get autoclean" did not complete successfully: exit code: 127
```