### PR TITLE
fix: Update el-link underline prop and add loggerFactory to MapperCon…

### DIFF
--- a/ClientApp/src/views/iot/devices/deviceBackup.vue
+++ b/ClientApp/src/views/iot/devices/deviceBackup.vue
@@ -37,7 +37,7 @@
       <el-table :data="state.tableData.rows" style="width: 100%" row-key="id" @row-click="rowOnClick">
         <el-table-column prop="name" label="设备名称" show-overflow-tooltip>
           <template #default="scope">
-            <el-link type="primary" :underline="false">{{ scope.row.name }}</el-link>
+            <el-link type="primary" underline="never">{{ scope.row.name }}</el-link>
           </template>
         </el-table-column>
 

--- a/ClientApp/src/views/login/component/account.vue
+++ b/ClientApp/src/views/login/component/account.vue
@@ -50,7 +50,7 @@
 
     <div class="mt10-40px login-animation5 text-center">
       没有账号?
-      <router-link to="/signup"> <el-link type="primary" :underline="false" >立即注册 </el-link></router-link>
+      <router-link to="/signup"> <el-link type="primary" underline="never" >立即注册 </el-link></router-link>
     </div>
   </el-form>
 

--- a/ClientApp/src/views/login/signup.vue
+++ b/ClientApp/src/views/login/signup.vue
@@ -15,7 +15,7 @@
                 </div>
                 <div class="mt10-40px login-animation5 text-center">
                     已有账号?
-                    <router-link to="/login"> <el-link type="primary" :underline="false">登录 </el-link></router-link>
+                    <router-link to="/login"> <el-link type="primary" underline="never">登录 </el-link></router-link>
                 </div>
             </div>
         </div>

--- a/IoTSharp/Controllers/DevicesController.cs
+++ b/IoTSharp/Controllers/DevicesController.cs
@@ -59,10 +59,11 @@ namespace IoTSharp.Controllers
         private readonly FlowRuleProcessor _flowRuleProcessor;
         private readonly IEasyCachingProvider _caching;
         private readonly IServiceScopeFactory _scopeFactor;
+        private readonly ILoggerFactory _loggerFactory;
 
         public DevicesController(UserManager<IdentityUser> userManager,
             SignInManager<IdentityUser> signInManager, ILogger<DevicesController> logger, MqttServer serverEx, ApplicationDbContext context, MqttClientOptions mqtt, IStorage storage, IOptions<AppSettings> options, IPublisher queue
-            , IEasyCachingProviderFactory factory, FlowRuleProcessor flowRuleProcessor, IServiceScopeFactory scopeFactor)
+            , IEasyCachingProviderFactory factory, FlowRuleProcessor flowRuleProcessor, IServiceScopeFactory scopeFactor, ILoggerFactory loggerFactory)
         {
             string _hc_Caching = $"{nameof(CachingUseIn)}-{Enum.GetName(options.Value.CachingUseIn)}";
             _context = context;
@@ -77,6 +78,7 @@ namespace IoTSharp.Controllers
             _flowRuleProcessor = flowRuleProcessor;
             _caching = factory.GetCachingProvider(_hc_Caching);
             _scopeFactor = scopeFactor;
+            _loggerFactory = loggerFactory;
         }
 
         /// <summary>
@@ -745,7 +747,7 @@ namespace IoTSharp.Controllers
             var dev = await PostDevice(dto);
             if (dev.Code == (int)ApiCode.Success)
             {
-                MapperConfiguration mapperConfiguration = new MapperConfiguration(options => { options.CreateMap<ProduceData, AttributeLatest>(); });
+                MapperConfiguration mapperConfiguration = new MapperConfiguration(options => { options.CreateMap<ProduceData, AttributeLatest>(); },_loggerFactory);
                 IMapper mapper = mapperConfiguration.CreateMapper();
 
                 var atts = produce.DefaultAttributes.Select(c =>


### PR DESCRIPTION
fix: Update el-link underline prop and add loggerFactory to MapperConfiguration

- Changed `:underline="false"` to `underline="never"` in `<el-link>` components to resolve Element Plus 3.0.0 deprecation warning.
- Added `_loggerFactory` as the second parameter to `MapperConfiguration` constructor to enable logging support.
- Ensured compliance with new Element Plus API for underline prop (`always`, `hover`, `never`).
- Ref: https://element-plus.org/en-US/component/link.html#underline